### PR TITLE
Feature position mgmt

### DIFF
--- a/app/controllers/users/position_management_controller.rb
+++ b/app/controllers/users/position_management_controller.rb
@@ -14,8 +14,6 @@ class Users::PositionManagementController < ApplicationController
   end
 
   def update
-    raise params.inspect
-    # binding.pry
     if current_user.update(user_position_params)
       redirect_to user_positions_path(current_user)
     else
@@ -25,8 +23,8 @@ class Users::PositionManagementController < ApplicationController
 
   private
   def user_position_params
-    params.require(:user).permit(:user_id, :position_ids[], positions_users_attributes: [:skill_level])
+    params.require(:user).permit(:user, positions_users_attributes: [:position_id, :skill_level])
   end
 end
 
-# <ActionController::Parameters {"utf8"=>"✓", "_method"=>"patch", "authenticity_token"=>"0DGcIiju/zzDHvfNK1bfvUwJ+BU91Kn4a22HpR/qjPdzoPlSCwHfREBZpHmGonQG4iIgaIegwiXMQ/RRZoY24Q==", "user"=>{"positions_users"=>[{"position_id"=>"", "skill_level"=>""}, {"position_id"=>""}, {"position_id"=>"2", "skill_level"=>"1"}]}, "commit"=>"Manage Position(s)", "controller"=>"users/position_management", "action"=>"update", "user_id"=>"1"} permitted: false>
+{"utf8"=>"✓", "_method"=>"patch", "authenticity_token"=>"7ygP/H3za91bM2UrP5TbeyN1EAhbPYCCCnvml14Yur5MuWqMXhxLpdh0Np+SYHDAjV7IdeFJ61+tVZVjJ3QAqA==", "user"=>{"positions_users_attributes"=>{"0"=>{"position_id"=>"1", "skill_level"=>"4"}, "1"=>{"skill_level"=>""}}}, "commit"=>"Update User", "controller"=>"users", "action"=>"update", "id"=>"1"}

--- a/app/controllers/users/position_management_controller.rb
+++ b/app/controllers/users/position_management_controller.rb
@@ -1,20 +1,32 @@
 class Users::PositionManagementController < ApplicationController
+  # def edit
+  #   positions_users = current_user.positions_users
+  #   Position.find_each do |position|
+  #     unless positions_users.detect {|pu| pu.position_id == position.id}
+  #       current_user.positions_users.build(position_id: position.id)#, skill_level: 0)
+  #     end
+  #   end
+  # end
 
   def edit
-    positions_users = current_user.positions_users
-    Position.find_each do |position|
-      unless positions_users.detect {|pu| pu.position_id == position.id}
-        current_user.positions_users.build(position_id: position.id)
-      end
-    end
+    @positions = Position.all
+    @positions_users = current_user.positions_users
   end
 
   def update
     raise params.inspect
-    if current_user.update(user_params)
+    # binding.pry
+    if current_user.update(user_position_params)
       redirect_to user_positions_path(current_user)
     else
       render 'edit'
     end
   end
+
+  private
+  def user_position_params
+    params.require(:user).permit(:user_id, :position_ids[], positions_users_attributes: [:skill_level])
+  end
 end
+
+# <ActionController::Parameters {"utf8"=>"✓", "_method"=>"patch", "authenticity_token"=>"0DGcIiju/zzDHvfNK1bfvUwJ+BU91Kn4a22HpR/qjPdzoPlSCwHfREBZpHmGonQG4iIgaIegwiXMQ/RRZoY24Q==", "user"=>{"positions_users"=>[{"position_id"=>"", "skill_level"=>""}, {"position_id"=>""}, {"position_id"=>"2", "skill_level"=>"1"}]}, "commit"=>"Manage Position(s)", "controller"=>"users/position_management", "action"=>"update", "user_id"=>"1"} permitted: false>

--- a/app/controllers/users/position_management_controller.rb
+++ b/app/controllers/users/position_management_controller.rb
@@ -1,0 +1,20 @@
+class Users::PositionManagementController < ApplicationController
+
+  def edit
+    positions_users = current_user.positions_users
+    Position.find_each do |position|
+      unless positions_users.detect {|pu| pu.position_id == position.id}
+        current_user.positions_users.build(position_id: position.id)
+      end
+    end
+  end
+
+  def update
+    raise params.inspect
+    if current_user.update(user_params)
+      redirect_to user_positions_path(current_user)
+    else
+      render 'edit'
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,11 +58,12 @@ class User < ApplicationRecord
 
   def positions_users_attributes=(pu_attributes)
     pu_attributes.keep_if {|i, j| j[:position_id].to_i > 0}
-
+    self.positions_users.destroy_all
     pu_attributes.each do |i, attributes|
       # binding.pry
-      # self.positions_users.build(attributes)
-      self.positions_users.find_or_initialize_by(attributes).update(attributes)
+      self.positions_users.build(attributes)
+      # self.positions_users.find_or_initialize_by(attributes).update(attributes)
+      # self.positions_users.find_or_initialize_by(attributes).assign_attributes(attributes)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,4 +55,22 @@ class User < ApplicationRecord
   # def positions=(position)
   #   self.positions << Position.find_by(name: position[:name])
   # end
+
+  def positions_users_attributes=(pu_attributes)
+    pu_attributes.keep_if {|i, j| j[:position_id].to_i > 0}
+
+    pu_attributes.each do |i, attributes|
+      # binding.pry
+      # self.positions_users.build(attributes)
+      self.positions_users.find_or_initialize_by(attributes).update(attributes)
+    end
+  end
+
+  def has_positions?(position)
+    self.position_ids.include?(position.id)
+  end
+
+  def skill_level(position)
+    self.positions_users.where("position_id = ?", position.id).first.skill_level
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
 
   validates :first_name, :last_name, :email, :phone_number, :weight, presence: true
 
+  accepts_nested_attributes_for :positions_users
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.id).first_or_create do |user|
       user.email = auth.info.email

--- a/app/views/users/position_management/edit.html.erb
+++ b/app/views/users/position_management/edit.html.erb
@@ -4,12 +4,22 @@ user::position_management#edit
 
 <h2>Manage the positions on your profile:</h2>
 
+
+
+<hr></br>
 <%= form_for current_user, url: user_position_management_path do |f| %>
   <%= f.fields_for :positions_users do |pu| %>
-      <%= check_box_tag "user[position_ids][]", :position_id, current_user.positions.include?(pu.object.position) %>
-      <%= pu.object.position.name %>
-      <%= pu.label :skill_level %>
-      <%= pu.number_field :skill_level %><br>
+    <%= hidden_field_tag "user[positions_users][][position_id]", nil%>
+    <%= check_box_tag "user[positions_users][][position_id]", pu.object.position.id %>
+    <%= label_tag pu.object.position.name %>
+    <%= label_tag "skill level" %>
+    <%= number_field_tag "user[positions_users][][skill_level]" %><br>
     <% end %>
   <%= f.submit "Manage Position(s)" %>
 <% end %>
+
+<hr>
+
+
+<!-- params if user already has a position/skill:
+<ActionController::Parameters {"utf8"=>"✓", "_method"=>"patch", "authenticity_token"=>"EMWl09snJIwDQfTYoi8eMIpyYLbpjJbpEunbpBnNFuizVMCj+MgE9IAGp2wP27WLJFm4y1P4/TS1x6hQYKGs/g==", "user"=>{"positions_users"=>[{"position_id"=>"2", "skill_level"=>"4"}, {"skill_level"=>""}], "positions_users_attributes"=>{"0"=>{"id"=>"1"}}}, "commit"=>"Manage Position(s)", "controller"=>"users/position_management", "action"=>"update", "user_id"=>"1"} permitted: false> -->

--- a/app/views/users/position_management/edit.html.erb
+++ b/app/views/users/position_management/edit.html.erb
@@ -7,19 +7,13 @@ user::position_management#edit
 
 
 <hr></br>
-<%= form_for current_user, url: user_position_management_path do |f| %>
-  <%= f.fields_for :positions_users do |pu| %>
-    <%= hidden_field_tag "user[positions_users][][position_id]", nil%>
-    <%= check_box_tag "user[positions_users][][position_id]", pu.object.position.id %>
-    <%= label_tag pu.object.position.name %>
-    <%= label_tag "skill level" %>
-    <%= number_field_tag "user[positions_users][][skill_level]" %><br>
+<%= form_for current_user do |f| %>
+  <% @positions.each do |position| %>
+    <%= f.fields_for :positions_users, PositionsUser.new do |pu_fields| %>
+      <%= pu_fields.check_box :position_id, {id: "position_#{position.id}"}, position.id, nil %>
+      <%= pu_fields.label :name, position.name, for: "position_#{position.id}" %>
+      <%= pu_fields.text_field :skill_level %><br>
     <% end %>
-  <%= f.submit "Manage Position(s)" %>
+  <% end %>
+  <%= f.submit %>
 <% end %>
-
-<hr>
-
-
-<!-- params if user already has a position/skill:
-<ActionController::Parameters {"utf8"=>"✓", "_method"=>"patch", "authenticity_token"=>"EMWl09snJIwDQfTYoi8eMIpyYLbpjJbpEunbpBnNFuizVMCj+MgE9IAGp2wP27WLJFm4y1P4/TS1x6hQYKGs/g==", "user"=>{"positions_users"=>[{"position_id"=>"2", "skill_level"=>"4"}, {"skill_level"=>""}], "positions_users_attributes"=>{"0"=>{"id"=>"1"}}}, "commit"=>"Manage Position(s)", "controller"=>"users/position_management", "action"=>"update", "user_id"=>"1"} permitted: false> -->

--- a/app/views/users/position_management/edit.html.erb
+++ b/app/views/users/position_management/edit.html.erb
@@ -10,10 +10,10 @@ user::position_management#edit
 <%= form_for current_user, url: user_position_management_path do |f| %>
   <% @positions.each do |position| %>
     <%= f.fields_for :positions_users, PositionsUser.new do |pu_fields| %>
-      <%= pu_fields.check_box :position_id, {id: "position_#{position.id}"}, position.id, nil %>
+      <%= pu_fields.check_box :position_id, {checked: current_user.has_positions?(position), id: "position_#{position.id}"}, position.id, nil %>
       <%= pu_fields.label :name, position.name, for: "position_#{position.id}" %>
-      <%= pu_fields.text_field :skill_level %><br>
+      <%= pu_fields.text_field :skill_level, value: current_user.has_positions?(position) ? current_user.skill_level(position) : '' %><br>
     <% end %>
   <% end %>
-  <%= f.submit %>
+  <%= f.submit "Manage Position(s)" %>
 <% end %>

--- a/app/views/users/position_management/edit.html.erb
+++ b/app/views/users/position_management/edit.html.erb
@@ -1,0 +1,15 @@
+<hr>
+user::position_management#edit
+
+
+<h2>Manage the positions on your profile:</h2>
+
+<%= form_for current_user, url: user_position_management_path do |f| %>
+  <%= f.fields_for :positions_users do |pu| %>
+      <%= check_box_tag "user[position_ids][]", :position_id, current_user.positions.include?(pu.object.position) %>
+      <%= pu.object.position.name %>
+      <%= pu.label :skill_level %>
+      <%= pu.number_field :skill_level %><br>
+    <% end %>
+  <%= f.submit "Manage Position(s)" %>
+<% end %>

--- a/app/views/users/position_management/edit.html.erb
+++ b/app/views/users/position_management/edit.html.erb
@@ -7,7 +7,7 @@ user::position_management#edit
 
 
 <hr></br>
-<%= form_for current_user do |f| %>
+<%= form_for current_user, url: user_position_management_path do |f| %>
   <% @positions.each do |position| %>
     <%= f.fields_for :positions_users, PositionsUser.new do |pu_fields| %>
       <%= pu_fields.check_box :position_id, {id: "position_#{position.id}"}, position.id, nil %>

--- a/app/views/users/positions/index.html.erb
+++ b/app/views/users/positions/index.html.erb
@@ -3,11 +3,11 @@ user::positions#index
 
 <h2><%= current_user.name %>'s positions</h2>
 <ul>
-  <% current_user.positions.each do |position| %>
-    <li><%= position.name %> </li>
+  <% current_user.positions_users.each do |pu| %>
+    <li><%= pu.position.name %> with a skill level of <%= pu.skill_level %></li>
   <% end %>
 </ul>
 
 
-<%= link_to "Add Positions", new_user_position_path(current_user) %>
-<%= link_to "Manage Positions", edit_user_path(current_user) %>
+<%= link_to "Manage Positions", user_position_management_path(current_user) %>
+<!-- <%= link_to "Manage Positions", edit_user_path(current_user) %> -->

--- a/app/views/users/positions/new.html.erb
+++ b/app/views/users/positions/new.html.erb
@@ -6,13 +6,10 @@ user::positions#new
 
 <%= form_for current_user do |f| %>
   <%= f.fields_for :positions_users do |pu| %>
-      <%= pu.check_box :position_id, {id: "position_id#{pu.object.position.id}"}, pu.object.position.id, nil %>
-      <%= pu.label :name, pu.object.position.name %>
+      <%= check_box_tag "user[position_ids][]", :position_id, current_user.positions.include?(pu.object.position) %>
+      <%= pu.object.position.name %>
       <%= pu.label :skill_level %>
       <%= pu.number_field :skill_level %><br>
     <% end %>
   <%= f.submit "Add Position(s)" %>
 <% end %>
-
-
-<!-- need to remove checkboxes?  form class shows as edit, not new -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
 
   resources :users do
     scope module: :users do
-      resources :positions, only: [:index, :create, :new]
+      get '/position-management', to: 'position_management#edit'  # Gives /users/:user_id/position-management(.:format) users/position_management#edit
+      patch '/position-management', to: 'position_management#update'
+      put '/position-management', to: 'position_management#update'
+      resources :positions, only: [:index]
       resources :boats
     end
   end

--- a/db/migrate/20180320230510_remove_not_null_constraint_on_positions_users.rb
+++ b/db/migrate/20180320230510_remove_not_null_constraint_on_positions_users.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintOnPositionsUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :positions_users, :skill_level, true
+  end
+end

--- a/db/migrate/20180320230855_add_timestamps_to_positions_users.rb
+++ b/db/migrate/20180320230855_add_timestamps_to_positions_users.rb
@@ -1,0 +1,11 @@
+class AddTimestampsToPositionsUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_timestamps :positions_users, null: true
+
+    long_ago = DateTime.new(2003, 8, 13)
+    PositionsUser.update_all(created_at: long_ago, updated_at: long_ago)
+
+    change_column_null :positions_users, :created_at, false
+    change_column_null :positions_users, :updated_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180217214429) do
+ActiveRecord::Schema.define(version: 20180320230855) do
 
   create_table "boats", force: :cascade do |t|
     t.string   "name"
@@ -32,9 +32,11 @@ ActiveRecord::Schema.define(version: 20180217214429) do
   end
 
   create_table "positions_users", force: :cascade do |t|
-    t.integer "position_id"
-    t.integer "user_id"
-    t.integer "skill_level", null: false
+    t.integer  "position_id"
+    t.integer  "user_id"
+    t.integer  "skill_level"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.index ["position_id"], name: "index_positions_users_on_position_id"
     t.index ["user_id"], name: "index_positions_users_on_user_id"
   end

--- a/spec/features/position_features_spec.rb
+++ b/spec/features/position_features_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Users and Positions', type: :feature do
       visit user_position_management_path(user.id)
 
       page.check(position2.name)
-      click_button("Update User")
+      click_button("Manage Position(s)")
 
       expect(user.positions).to include(position1, position2)
     end

--- a/spec/features/position_features_spec.rb
+++ b/spec/features/position_features_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Users and Positions', type: :feature do
       user = create(:user)
 
       visit user_positions_path(user.id)
+
       expect(page.status_code).to eq(200)
     end
   end
@@ -16,6 +17,7 @@ RSpec.feature 'Users and Positions', type: :feature do
       signin(user.email, user.password)
 
       visit user_positions_path(user.id)
+
       expect(page).to have_link("Add Positions")
     end
 
@@ -25,6 +27,7 @@ RSpec.feature 'Users and Positions', type: :feature do
 
       visit user_positions_path(user.id)
       click_link("Add Positions")
+
       expect(page).to have_css("form#new_user_#{user.id}")
     end
 
@@ -69,8 +72,6 @@ RSpec.feature 'Users and Positions', type: :feature do
       position2 = create(:position)
       user = create(:user)
 
-      # PositionsUser.create(user_id: user.id, position_id: position1.id, skill_level: 3)
-      binding.pry
       signin(user.email, user.password)
       visit user_position_management_path(user.id)
 
@@ -78,30 +79,41 @@ RSpec.feature 'Users and Positions', type: :feature do
       expect(page).to have_content(position2.name)
     end
 
-    xscenario 'the form should indicate which position(s) are already listed in the user profile' do
+    scenario 'the form should display checkboxes for the existing positions in the db' do
       position1 = create(:position)
       position2 = create(:position)
       user = create(:user)
-      user.positions << position1
 
       signin(user.email, user.password)
-      visit edit_user_path(user.id)
+      visit user_position_management_path(user.id)
 
-      expect(page).to have_field("user_position_ids_#{position1.id}", checked: true)
-      expect(page).to have_field("user_position_ids_#{position2.id}", checked: false)
+      expect(page).to have_css("input[type=\"checkbox\"]", count: 2)
     end
 
-    xscenario 'the list of positions for a user should update after the form is submitted' do
+    scenario 'the form should indicate which position(s) are already listed in the user profile' do
       position1 = create(:position)
       position2 = create(:position)
       user = create(:user)
       user.positions << position1
 
       signin(user.email, user.password)
-      visit edit_user_path(user.id)
+      visit user_position_management_path(user.id)
+
+      expect(page).to have_field("position_#{position1.id}", checked: true)
+      expect(page).to have_field("position_#{position2.id}", checked: false)
+    end
+
+    scenario 'the list of positions for a user should update after the form is submitted' do
+      position1 = create(:position)
+      position2 = create(:position)
+      user = create(:user)
+      user.positions << position1
+
+      signin(user.email, user.password)
+      visit user_position_management_path(user.id)
 
       page.check(position2.name)
-      click_button("Update Position(s)")
+      click_button("Update User")
 
       expect(user.positions).to include(position1, position2)
     end

--- a/spec/features/position_features_spec.rb
+++ b/spec/features/position_features_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Users and Positions', type: :feature do
     end
   end
 
-  context 'user wants to add positions to their profile' do
+  xcontext 'user wants to add positions to their profile' do
     scenario 'there is a link to add new positions' do
       user = create(:user)
       signin(user.email, user.password)
@@ -50,26 +50,29 @@ RSpec.feature 'Users and Positions', type: :feature do
       signin(user.email, user.password)
 
       visit user_positions_path(user.id)
+
       expect(page).to have_link("Manage Positions")
     end
 
-    xscenario 'there is a form to update positions associated with user profile' do
+    scenario 'there is a form to update positions associated with user profile' do
       user = create(:user)
       signin(user.email, user.password)
+
       visit user_positions_path(user.id)
       click_link("Manage Positions")
+
       expect(page).to have_css("form#edit_user_#{user.id}")
     end
 
-    xscenario 'the form should display existing positions in the db' do
+    scenario 'the form should display existing positions in the db' do
       position1 = create(:position)
       position2 = create(:position)
       user = create(:user)
 
-      PositionsUser.create(user_id: user.id, position_id: position1.id, skill_level: 3)
+      # PositionsUser.create(user_id: user.id, position_id: position1.id, skill_level: 3)
       binding.pry
       signin(user.email, user.password)
-      visit edit_user_path(user.id)
+      visit user_position_management_path(user.id)
 
       expect(page).to have_content(position1.name)
       expect(page).to have_content(position2.name)

--- a/spec/features/position_features_spec.rb
+++ b/spec/features/position_features_spec.rb
@@ -117,5 +117,20 @@ RSpec.feature 'Users and Positions', type: :feature do
 
       expect(user.positions).to include(position1, position2)
     end
+
+    scenario 'form submission updates an existing profile position and does not create a new one' do
+      position1 = create(:position)
+      user = create(:user)
+      user.positions_users << PositionsUser.create(user_id: user.id, position_id: position1.id, skill_level: 2)
+
+      signin(user.email, user.password)
+      visit user_position_management_path(user.id)
+      fill_in 'user[positions_users_attributes][0][skill_level]', with: 5
+      click_button("Manage Position(s)")
+
+      expect(user.positions.count).to eq(1)
+      expect(user.positions_users.count).to eq(1)
+      expect(user.positions_users.first.skill_level).to eq(5)
+    end
   end
 end


### PR DESCRIPTION
Implements one way to allow users to manage the profiles in their positions.  User position profile is treated as created and empty when user signs up; therefore, user is always editing/updating positions.  Approach eliminates existing user.positions_users table entries during mass assignment (as opposed to updating existing rows, creating new ones as needed).